### PR TITLE
Add deprecation note to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # Access To Memory replication playbook
 
+## IMPORTANT: This playbook is now deprecated and no longer being supported
+
+For a newer, improved version of the AtoM replication playbook, please see: 
+
+* https://github.com/artefactual-labs/ansible-atom-replication
+
+-----
+
 This playbook will take care of:
  - Configure ES snapshots on source and destination servers
  - Create elasticsearch and mysql backups for the source atom instance


### PR DESCRIPTION
After a lot of internal work, we are now using the following as our main repo for maintaining the current best version of the AtoM replication script: 

* https://github.com/artefactual-labs/ansible-atom-replication

This PR simply updates the README to indicate that this repository is now deprecated, and to point users to the updated repo. I'm doing this rather than deleting or archiving the project entirely, since we have slide decks and other public resources out there that point to this repo. 